### PR TITLE
Add BL-Touch throughs timer conflict error message

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1544,7 +1544,7 @@
  *     |    [-]    |
  *     O-- FRONT --+
  */
-#define NOZZLE_TO_PROBE_OFFSET { 0, 0, 22.2 }
+#define NOZZLE_TO_PROBE_OFFSET { 0, 22.2, 0 }
 
 // Most probes should stay away from the edges of the bed, but
 // with NOZZLE_AS_PROBE this can be negative for a wider probing area.
@@ -1767,11 +1767,11 @@
 #define Y_BED_SIZE 230
 
 // Travel limits (linear=mm, rotational=°) after homing, corresponding to endstop positions.
-#define X_MIN_POS -11.0
-#define Y_MIN_POS -26.4
+#define X_MIN_POS 11.0
+#define Y_MIN_POS 26.4
 #define Z_MIN_POS 0
-#define X_MAX_POS (X_BED_SIZE - X_MIN_POS)
-#define Y_MAX_POS (Y_BED_SIZE - Y_MIN_POS)
+#define X_MAX_POS (X_BED_SIZE + X_MIN_POS + 0.1)
+#define Y_MAX_POS (Y_BED_SIZE + Y_MIN_POS + 0.1)
 #define Z_MAX_POS 260
 //#define I_MIN_POS 0
 //#define I_MAX_POS 50

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1768,7 +1768,7 @@
 
 // Travel limits (linear=mm, rotational=°) after homing, corresponding to endstop positions.
 #define X_MIN_POS -20.0
-#define Y_MIN_POS 10
+#define Y_MIN_POS -0
 #define Z_MIN_POS 0
 #define X_MAX_POS X_BED_SIZE
 #define Y_MAX_POS Y_BED_SIZE

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1770,8 +1770,8 @@
 #define X_MIN_POS -11.0
 #define Y_MIN_POS -26.4
 #define Z_MIN_POS 0
-#define X_MAX_POS X_BED_SIZE
-#define Y_MAX_POS Y_BED_SIZE
+#define X_MAX_POS {X_BED_SIZE - X_MIN_POS}
+#define Y_MAX_POS {Y_BED_SIZE - Y_MIN_POS}
 #define Z_MAX_POS 260
 //#define I_MIN_POS 0
 //#define I_MAX_POS 50

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1767,8 +1767,8 @@
 #define Y_BED_SIZE 230
 
 // Travel limits (linear=mm, rotational=°) after homing, corresponding to endstop positions.
-#define X_MIN_POS -11.0
-#define Y_MIN_POS -21.4
+#define X_MIN_POS -20.0
+#define Y_MIN_POS 10
 #define Z_MIN_POS 0
 #define X_MAX_POS X_BED_SIZE
 #define Y_MAX_POS Y_BED_SIZE

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1768,10 +1768,10 @@
 
 // Travel limits (linear=mm, rotational=°) after homing, corresponding to endstop positions.
 #define X_MIN_POS -14.0 // distance between the left edge of the printing bed and X_MIN_STOP
-#define Y_MIN_POS -37.0 // distance between the front edge of the printing bed and Y_MIN_STOP
+#define Y_MIN_POS -36.0 // distance between the front edge of the printing bed and Y_MIN_STOP
 #define Z_MIN_POS 0
-#define X_MAX_OFFSET 21.0 // distance between the right edge of the printing bed and X_MAX_STOP
-#define Y_MAX_OFFSET 2.0 // distance between the back edge of the printing bed and Y_MAX_STOP
+#define X_MAX_OFFSET 19.0 // distance between the right edge of the printing bed and X_MAX_STOP
+#define Y_MAX_OFFSET 3.0 // distance between the back edge of the printing bed and Y_MAX_STOP
 #define X_MAX_POS (X_BED_SIZE + X_MAX_OFFSET ) // maximum movement bounds (X_MIN_POS to X_MAX_POS)
 #define Y_MAX_POS (Y_BED_SIZE + Y_MAX_OFFSET ) // maximum movement bounds (Y_MIN_POS to Y_MAX_POS)
 #define Z_MAX_POS 260
@@ -2145,7 +2145,7 @@
 // Manually set the home position. Leave these undefined for automatic settings.
 // For DELTA this is the top-center of the Cartesian print volume.
 #define MANUAL_X_HOME_POS -14.0
-#define MANUAL_Y_HOME_POS -37.0
+#define MANUAL_Y_HOME_POS -36.0
 //#define MANUAL_Z_HOME_POS 0    //was 1.4
 //#define MANUAL_I_HOME_POS 0
 //#define MANUAL_J_HOME_POS 0

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1544,7 +1544,7 @@
  *     |    [-]    |
  *     O-- FRONT --+
  */
-#define NOZZLE_TO_PROBE_OFFSET { 0, 0, 22.2 }
+#define NOZZLE_TO_PROBE_OFFSET { 0, 22.2, -0.5}
 
 // Most probes should stay away from the edges of the bed, but
 // with NOZZLE_AS_PROBE this can be negative for a wider probing area.
@@ -1767,8 +1767,8 @@
 #define Y_BED_SIZE 230
 
 // Travel limits (linear=mm, rotational=°) after homing, corresponding to endstop positions.
-#define X_MIN_POS -1.0
-#define Y_MIN_POS -6.4
+#define X_MIN_POS -11.0
+#define Y_MIN_POS -21.4
 #define Z_MIN_POS 0
 #define X_MAX_POS X_BED_SIZE
 #define Y_MAX_POS Y_BED_SIZE

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1763,15 +1763,15 @@
 // @section geometry
 
 // The size of the printable area
-#define X_BED_SIZE 230
-#define Y_BED_SIZE 230
+#define X_BED_SIZE 224
+#define Y_BED_SIZE 224
 
 // Travel limits (linear=mm, rotational=°) after homing, corresponding to endstop positions.
-#define X_MIN_POS -11.0 // distance between the left edge of the printing bed and X_MIN_STOP
-#define Y_MIN_POS -26.4 // distance between the front edge of the printing bed and Y_MIN_STOP
+#define X_MIN_POS -14.0 // distance between the left edge of the printing bed and X_MIN_STOP
+#define Y_MIN_POS -14.0 // distance between the front edge of the printing bed and Y_MIN_STOP
 #define Z_MIN_POS 0
-#define X_MAX_OFFSET 10.0 // distance between the right edge of the printing bed and X_MAX_STOP
-#define Y_MAX_OFFSET 25.0 // distance between the back edge of the printing bed and Y_MAX_STOP
+#define X_MAX_OFFSET 23.0 // distance between the right edge of the printing bed and X_MAX_STOP
+#define Y_MAX_OFFSET 14.0 // distance between the back edge of the printing bed and Y_MAX_STOP
 #define X_MAX_POS (X_BED_SIZE + X_MAX_OFFSET ) // maximum movement bounds (X_MIN_POS to X_MAX_POS)
 #define Y_MAX_POS (Y_BED_SIZE + Y_MAX_OFFSET ) // maximum movement bounds (Y_MIN_POS to Y_MAX_POS)
 #define Z_MAX_POS 260
@@ -2144,8 +2144,8 @@
 
 // Manually set the home position. Leave these undefined for automatic settings.
 // For DELTA this is the top-center of the Cartesian print volume.
-#define MANUAL_X_HOME_POS -11.0
-#define MANUAL_Y_HOME_POS -21.4
+#define MANUAL_X_HOME_POS -14.0
+#define MANUAL_Y_HOME_POS -14.0
 //#define MANUAL_Z_HOME_POS 0    //was 1.4
 //#define MANUAL_I_HOME_POS 0
 //#define MANUAL_J_HOME_POS 0

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1770,8 +1770,8 @@
 #define X_MIN_POS -11.0
 #define Y_MIN_POS -26.4
 #define Z_MIN_POS 0
-#define X_MAX_POS {X_BED_SIZE - X_MIN_POS}
-#define Y_MAX_POS {Y_BED_SIZE - Y_MIN_POS}
+#define X_MAX_POS (X_BED_SIZE - X_MIN_POS)
+#define Y_MAX_POS (Y_BED_SIZE - Y_MIN_POS)
 #define Z_MAX_POS 260
 //#define I_MIN_POS 0
 //#define I_MAX_POS 50

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1767,11 +1767,11 @@
 #define Y_BED_SIZE 230
 
 // Travel limits (linear=mm, rotational=°) after homing, corresponding to endstop positions.
-#define X_MIN_POS 11.0
-#define Y_MIN_POS 26.4
+#define X_MIN_POS -11.0
+#define Y_MIN_POS -26.4
 #define Z_MIN_POS 0
-#define X_MAX_POS (X_BED_SIZE + X_MIN_POS + 0.1)
-#define Y_MAX_POS (Y_BED_SIZE + Y_MIN_POS + 0.1)
+#define X_MAX_POS (X_BED_SIZE - X_MIN_POS + 0.1)
+#define Y_MAX_POS (Y_BED_SIZE - Y_MIN_POS + 0.1)
 #define Z_MAX_POS 260
 //#define I_MIN_POS 0
 //#define I_MAX_POS 50

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1767,11 +1767,13 @@
 #define Y_BED_SIZE 230
 
 // Travel limits (linear=mm, rotational=°) after homing, corresponding to endstop positions.
-#define X_MIN_POS -11.0
-#define Y_MIN_POS -26.4
+#define X_MIN_POS -11.0 // distance between the left edge of the printing bed and X_MIN_STOP
+#define Y_MIN_POS -26.4 // distance between the front edge of the printing bed and Y_MIN_STOP
 #define Z_MIN_POS 0
-#define X_MAX_POS (X_BED_SIZE - X_MIN_POS + 0.1)
-#define Y_MAX_POS (Y_BED_SIZE - Y_MIN_POS + 0.1)
+#define X_MAX_OFFSET 10.0 // distance between the right edge of the printing bed and X_MAX_STOP
+#define Y_MAX_OFFSET 25.0 // distance between the back edge of the printing bed and Y_MAX_STOP
+#define X_MAX_POS (X_BED_SIZE + X_MAX_OFFSET ) // maximum movement bounds (X_MIN_POS to X_MAX_POS)
+#define Y_MAX_POS (Y_BED_SIZE + Y_MAX_OFFSET ) // maximum movement bounds (Y_MIN_POS to Y_MAX_POS)
 #define Z_MAX_POS 260
 //#define I_MIN_POS 0
 //#define I_MAX_POS 50
@@ -2142,8 +2144,8 @@
 
 // Manually set the home position. Leave these undefined for automatic settings.
 // For DELTA this is the top-center of the Cartesian print volume.
-#define MANUAL_X_HOME_POS -1.0
-#define MANUAL_Y_HOME_POS -6.4
+#define MANUAL_X_HOME_POS -11.0
+#define MANUAL_Y_HOME_POS -21.4
 //#define MANUAL_Z_HOME_POS 0    //was 1.4
 //#define MANUAL_I_HOME_POS 0
 //#define MANUAL_J_HOME_POS 0

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1174,7 +1174,7 @@
 #define U_MAX_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
 #define V_MAX_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
 #define W_MAX_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
-#define Z_MIN_PROBE_ENDSTOP_INVERTING true // Set to true to invert the logic of the probe.
+#define Z_MIN_PROBE_ENDSTOP_INVERTING false // Set to true to invert the logic of the probe.
 
 // Enable this feature if all enabled endstop pins are interrupt-capable.
 // This will remove the need to poll the interrupt pins, saving many CPU cycles.
@@ -1381,7 +1381,7 @@
  * Use the nozzle as the probe, as with a conductive
  * nozzle system or a piezo-electric smart effector.
  */
-#define NOZZLE_AS_PROBE
+//#define NOZZLE_AS_PROBE
 
 /**
  * Z Servo Probe, such as an endstop switch on a rotating arm.
@@ -1392,7 +1392,7 @@
 /**
  * The BLTouch probe uses a Hall effect sensor and emulates a servo.
  */
-//#define BLTOUCH
+#define BLTOUCH
 
 /**
  * MagLev V4 probe by MDD
@@ -1544,7 +1544,7 @@
  *     |    [-]    |
  *     O-- FRONT --+
  */
-#define NOZZLE_TO_PROBE_OFFSET { 0, 0, 0 }
+#define NOZZLE_TO_PROBE_OFFSET { 0, 0, 22.2 }
 
 // Most probes should stay away from the edges of the bed, but
 // with NOZZLE_AS_PROBE this can be negative for a wider probing area.
@@ -3054,7 +3054,7 @@
 // Compatible DWIN part number DMG48270C043_03WTC, 272x480
 // Also Vyper community edition DWIN display
 // Compatible DWIN part number DMG80480C043_02WTR, 480x800
-// 
+//
 #define DGUS_LCD_UI_CREALITY_TOUCH
 #define DGUS_LCD_UI_CREALITY_TOUCH_ORIENTATION 2 // Orientation: 0, 1, 2, 3 for 0,90,180,270 degrees respectively
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1544,7 +1544,7 @@
  *     |    [-]    |
  *     O-- FRONT --+
  */
-#define NOZZLE_TO_PROBE_OFFSET { 0, 22.2, 0 }
+#define NOZZLE_TO_PROBE_OFFSET { 0, 0, 22.2 }
 
 // Most probes should stay away from the edges of the bed, but
 // with NOZZLE_AS_PROBE this can be negative for a wider probing area.
@@ -1763,12 +1763,12 @@
 // @section geometry
 
 // The size of the printable area
-#define X_BED_SIZE 250
-#define Y_BED_SIZE 255
+#define X_BED_SIZE 230
+#define Y_BED_SIZE 230
 
 // Travel limits (linear=mm, rotational=°) after homing, corresponding to endstop positions.
-#define X_MIN_POS -1.0
-#define Y_MIN_POS -6.4
+#define X_MIN_POS -11.0
+#define Y_MIN_POS -26.4
 #define Z_MIN_POS 0
 #define X_MAX_POS X_BED_SIZE
 #define Y_MAX_POS Y_BED_SIZE

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1578,7 +1578,7 @@
  * Useful for a strain gauge or piezo sensor that needs to factor out
  * elements such as cables pulling on the carriage.
  */
-#define PROBE_TARE
+//#define PROBE_TARE
 #if ENABLED(PROBE_TARE)
   #define PROBE_TARE_TIME  300    // (ms) Time to hold tare pin
   #define PROBE_TARE_DELAY 200    // (ms) Delay after tare before
@@ -1655,7 +1655,7 @@
  * These options are most useful for the BLTouch probe, but may also improve
  * readings with inductive probes and piezo sensors.
  */
-#define PROBING_HEATERS_OFF       // Turn heaters off when probing
+//#define PROBING_HEATERS_OFF       // Turn heaters off when probing
 #if ENABLED(PROBING_HEATERS_OFF)
   #define WAIT_ONLY_FOR_HOTEND
   //#define WAIT_FOR_BED_HEATER     // Wait for bed to heat back up between probes (to improve accuracy)
@@ -1763,8 +1763,8 @@
 // @section geometry
 
 // The size of the printable area
-#define X_BED_SIZE 250
-#define Y_BED_SIZE 255
+#define X_BED_SIZE 230
+#define Y_BED_SIZE 230
 
 // Travel limits (linear=mm, rotational=°) after homing, corresponding to endstop positions.
 #define X_MIN_POS -1.0
@@ -1772,7 +1772,7 @@
 #define Z_MIN_POS 0
 #define X_MAX_POS X_BED_SIZE
 #define Y_MAX_POS Y_BED_SIZE
-#define Z_MAX_POS 265
+#define Z_MAX_POS 260
 //#define I_MIN_POS 0
 //#define I_MAX_POS 50
 //#define J_MIN_POS 0

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1768,10 +1768,10 @@
 
 // Travel limits (linear=mm, rotational=°) after homing, corresponding to endstop positions.
 #define X_MIN_POS -14.0 // distance between the left edge of the printing bed and X_MIN_STOP
-#define Y_MIN_POS -14.0 // distance between the front edge of the printing bed and Y_MIN_STOP
+#define Y_MIN_POS -37.0 // distance between the front edge of the printing bed and Y_MIN_STOP
 #define Z_MIN_POS 0
-#define X_MAX_OFFSET 23.0 // distance between the right edge of the printing bed and X_MAX_STOP
-#define Y_MAX_OFFSET 14.0 // distance between the back edge of the printing bed and Y_MAX_STOP
+#define X_MAX_OFFSET 21.0 // distance between the right edge of the printing bed and X_MAX_STOP
+#define Y_MAX_OFFSET 2.0 // distance between the back edge of the printing bed and Y_MAX_STOP
 #define X_MAX_POS (X_BED_SIZE + X_MAX_OFFSET ) // maximum movement bounds (X_MIN_POS to X_MAX_POS)
 #define Y_MAX_POS (Y_BED_SIZE + Y_MAX_OFFSET ) // maximum movement bounds (Y_MIN_POS to Y_MAX_POS)
 #define Z_MAX_POS 260
@@ -2145,7 +2145,7 @@
 // Manually set the home position. Leave these undefined for automatic settings.
 // For DELTA this is the top-center of the Cartesian print volume.
 #define MANUAL_X_HOME_POS -14.0
-#define MANUAL_Y_HOME_POS -14.0
+#define MANUAL_Y_HOME_POS -37.0
 //#define MANUAL_Z_HOME_POS 0    //was 1.4
 //#define MANUAL_I_HOME_POS 0
 //#define MANUAL_J_HOME_POS 0

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1544,7 +1544,7 @@
  *     |    [-]    |
  *     O-- FRONT --+
  */
-#define NOZZLE_TO_PROBE_OFFSET { 0, 22.2, -0.5}
+#define NOZZLE_TO_PROBE_OFFSET { 0, 22.2, 0 }
 
 // Most probes should stay away from the edges of the bed, but
 // with NOZZLE_AS_PROBE this can be negative for a wider probing area.
@@ -1763,12 +1763,12 @@
 // @section geometry
 
 // The size of the printable area
-#define X_BED_SIZE 230
-#define Y_BED_SIZE 230
+#define X_BED_SIZE 250
+#define Y_BED_SIZE 255
 
 // Travel limits (linear=mm, rotational=°) after homing, corresponding to endstop positions.
-#define X_MIN_POS -20.0
-#define Y_MIN_POS -0
+#define X_MIN_POS -1.0
+#define Y_MIN_POS -6.4
 #define Z_MIN_POS 0
 #define X_MAX_POS X_BED_SIZE
 #define Y_MAX_POS Y_BED_SIZE

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -838,7 +838,7 @@
 
    #if DISABLED(VYPER_NOZZLE_HOMING)
     #define Z_MULTI_ENDSTOPS          // Other Z axes have their own endstops
-  #endif          
+  #endif
   #if ENABLED(Z_MULTI_ENDSTOPS)
     #define Z2_USE_ENDSTOP   _XMAX_   // Z2 endstop board plug. Don't forget to enable USE_*_PLUG.
     #define Z2_ENDSTOP_ADJUSTMENT 0   // Z2 offset relative to Z endstop

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1377,7 +1377,7 @@
 //#define LCD_BACKLIGHT_TIMEOUT_MINS 1  // (minutes) Timeout before turning off the backlight
 
 #if HAS_BED_PROBE && EITHER(HAS_MARLINUI_MENU, HAS_TFT_LVGL_UI)
-  //#define PROBE_OFFSET_WIZARD       // Add a Probe Z Offset calibration option to the LCD menu
+  #define PROBE_OFFSET_WIZARD       // Add a Probe Z Offset calibration option to the LCD menu
   #if ENABLED(PROBE_OFFSET_WIZARD)
     /**
      * Enable to init the Probe Z-Offset when starting the Wizard.

--- a/Marlin/src/pins/stm32f1/pins_AC_TRI_F1_V1.h
+++ b/Marlin/src/pins/stm32f1/pins_AC_TRI_F1_V1.h
@@ -35,7 +35,7 @@
 #define DISABLE_DEBUG
 
 // Avoid conflict with TIMER_SERVO when using the STM32 HAL
-#define TEMP_TIMER                          5
+//#define TEMP_TIMER                          5
 
 //
 // EEPROM

--- a/Marlin/src/pins/stm32f1/pins_AC_TRI_F1_V1.h
+++ b/Marlin/src/pins/stm32f1/pins_AC_TRI_F1_V1.h
@@ -132,17 +132,20 @@
 #define MAIN_VOLTAGE_MEASURE_PIN            PA6
 #define AUTO_LEVEL_TX_PIN                   PB13
 #define AUTO_LEVEL_RX_PIN                   PB12
-#define PROBE_TARE_PIN                      AUTO_LEVEL_TX_PIN
-#define Z_MIN_PROBE_PIN                     AUTO_LEVEL_RX_PIN
+//#define PROBE_TARE_PIN                      AUTO_LEVEL_TX_PIN
+//#define Z_MIN_PROBE_PIN                     AUTO_LEVEL_RX_PIN
 #define NEOPIXEL_PIN                        PB14    // neopixel LED driving pin
 #define PROBE_ACTIVATION_SWITCH_PIN         PB2
+
+#define SERVO0_PIN                          AUTO_LEVEL_TX_PIN
+#define Z_MIN_PROBE_PIN                     AUTO_LEVEL_RX_PIN
 
 //
 // SD Card
 //
 #ifndef ONBOARD_SDIO
   #define ONBOARD_SDIO
-#endif 
+#endif
 
 #define SD_DETECT_PIN                         PC7
 
@@ -192,7 +195,7 @@
 
   #define E0_SERIAL_TX_PIN                  PA11
   #define E0_SERIAL_RX_PIN                  PA12
-  
+
   #define E1_SERIAL_TX_PIN                  -1
   #define E1_SERIAL_RX_PIN                  -1
 

--- a/buildroot/share/PlatformIO/variants/MARLIN_F103Rx/variant.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_F103Rx/variant.h
@@ -129,6 +129,7 @@ extern "C" {
   #define TIMER_TONE            TIM3  // TIMER_TONE must be defined in this file
 #endif
 #ifndef TIMER_SERVO
+  #undef TIMER_SERVO
   #define TIMER_SERVO           TIM2  // TIMER_SERVO must be defined in this file
 #endif
 


### PR DESCRIPTION
### Description

First I tried to compile then CR6Community and after I spent the last two days in adopting pmatsol58s code to newest version of marlin I finally found your repository again:-)
Is it correct that your code is based on these repos?
https://github.com/CR6Community/Marlin ;   https://github.com/Pmatsol58/VyperCE6.1

After I created a Pull-Request to merge (my tries to merge above code into the most recent version of marlin causing linking errors) yesterday, https://github.com/CR6Community/Marlin/pull/349 , I tried to add support for BL-Touch using CR6Community, VyperCE6.1 as well as your repo Vyper_MB_CE_6.2 today.

Today I tried to add support for BL-Touch using your version of marlin but entered the same 'One or more timer are in conflict' error as yesterday with the other versions.

How can I solve these timer-issues and support BLtouch on a STM32F103 Tri-Gorilla V006 board?
Unfortunately my motherboard (original Vyper Tri-Gorilla V006 board) is using the GD32F103RET6 instead of the STM32F103.
I have already modified my motherboard a lot (adding a mosfet, several resistors, a screw terminal and a LED to support a second heater, Heater1), did a stealthBurner mod and more but the most clearly option to modify this board should be to support USB natively since there are places for 22-68Ohmes series resistors for native USB which are currently not assembled.
So it should be possible to add support for native USB instead of the serial to USB conversion.
Consequently there will be options for USB-OTG (USB-HumanInputDevice HID) plug and play (CH341 requires special drivers) and to connect to the computer the mainboard as MassStorageDevice.

But in this Pull request I only ask on how to solve the 'timer conflict' in order to support BL-Touch?

I invested many time to combine the StealthBurner mod with BLtouch in behind the nozzle, change to your community-firmware, adopted my Vyper to use a Glassbed of less size originally intended for use with CrealityEnder or CR6 and now I want to speed up support for Marlin and Vyper. I will invest some more time in testing the firmware, adding support for different hardware (Relays-switched-dual-extruder, XOR-Gate shared dual filament movement sensors or a wired-or/wired-and Filament-runout-Sensor) as well as support of native USB (Vyper uses a CH341 bridge but native USB DN and DP can be connected via 22Ohmes to the USB-B receptacle.)

### Requirements

BL-Touch

### Benefits

Replace the unreliable strain-gauge by a more reliable BL-Touch sensor.
Replace the CH321 by native USB to support plug & play as well as to add the ability to interact with the computer as mass storage device to put files on.

### Configurations

See the only commit in this PR

### Related Issues

Bed leveling with strain-gauge is bad because it does not support StealthBurner modification and it is not that reliable.
Timer error although a definition '#define TEMP_TIMER  5' is already in your configuration for Tri-Gorilla-Mainboard